### PR TITLE
cmake: fix warning in FindJUPYTER

### DIFF
--- a/CMakeModules/FindJUPYTER_NBCONVERT.cmake
+++ b/CMakeModules/FindJUPYTER_NBCONVERT.cmake
@@ -20,10 +20,8 @@
 #
 
 find_program(JUPYTER_EXECUTABLE NAMES jupyter DOC "Interactive computing environment (https://jupyter.org/)")
-include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(JUPYTER REQUIRED_VARS JUPYTER_EXECUTABLE)
 
-if(JUPYTER_FOUND)
+if(JUPYTER_EXECUTABLE)
   execute_process(COMMAND ${JUPYTER_EXECUTABLE} nbconvert --version
     OUTPUT_VARIABLE nbconvert_version
     ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
@@ -33,4 +31,6 @@ if(JUPYTER_FOUND)
     set(JUPYTER_NBCONVERT_VERSION 0.0)
   endif()
 endif()
+
+include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(JUPYTER_NBCONVERT REQUIRED_VARS JUPYTER_EXECUTABLE VERSION_VAR JUPYTER_NBCONVERT_VERSION)


### PR DESCRIPTION
Helps with:
The package name passed to `find_package_handle_standard_args` (JUPYTER)
does not match the name of the calling package (JUPYTER_NBCONVERT).  This
can lead to problems in calling code that expects `find_package` result
variables (e.g., `_FOUND`) to follow a certain pattern.