### PR TITLE
Set the neighborlist to use segmentname method

### DIFF
--- a/GROMACS/Methane/QMMM_GROMACS.ipynb
+++ b/GROMACS/Methane/QMMM_GROMACS.ipynb
@@ -214,7 +214,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Then we will set the *cutoff* for the pairs to 0.5 nanometers. See the [neighborlist options](https://votca.github.io/neighborlist.html) for further information. "
+    "Then we will use `segmentname` method to select the cutoff and set the *exciton_cutoff* for the pairs to 0.5 nanometers. See the [neighborlist options](https://votca.github.io/neighborlist.html) for further information. "
    ]
   },
   {
@@ -233,6 +233,9 @@
     "</segments>\n",
     "\"\"\"\n",
     "constant = \"\"\"<constant help=\"cutoff for all other types of pairs\">0.6</constant>\"\"\"\n",
+    "cutoff_type = \"\"\"<cutoff_type>segmentname</cutoff_type>\"\"\"\n",
+    "\n",
+    "add_section(\"neighborlist\", cutoff_type)\n",
     "add_section(\"neighborlist\", exciton_cutoff)\n",
     "add_section(\"neighborlist\", segments)\n",
     "add_section(\"neighborlist\", constant)"

--- a/clean_notebooks.sh
+++ b/clean_notebooks.sh
@@ -3,7 +3,7 @@
 
 files=("GROMACS/Methane/QMMM_GROMACS.ipynb" "LAMMPS/KMC_Thiophene/LAMMPS_KMC.ipynb" "LAMMPS/Thiophene/QMMM_LAMMPS.ipynb" "tools/dftgwbse_CH4/DFTGWBSE_ENERGY.ipynb" "tools/dftgwbse_CO_geoopt/DFTGWBSE_OPTIMIZATION.ipynb")
 
-for x in "${files[*]}"
+for x in ${files}
 do
     jupyter nbconvert --ClearOutputPreprocessor.enabled=True --inplace "${x}"
 done


### PR DESCRIPTION
## Proposed changes
Due to the XTP issues [votca/xtp#508](https://github.com/votca/xtp/issues/508) and [votca/xtp#511](https://github.com/votca/xtp/issues/511) new flags have been introduced to explicitly request a method. For instance, in the [neighborlist calculator](https://github.com/votca/xtp/blob/master/share/xtp/xml/neighborlist.xml) the `cutoff_type` flag is used to select how to apply the cutoff