### PR TITLE
set jupyter nbconvert logging to debug

### DIFF
--- a/share/doc/CMakeLists.txt
+++ b/share/doc/CMakeLists.txt
@@ -39,7 +39,7 @@ if(VOTCA_SPHINX_DIR)
       file(GLOB FILES ${PROJECT_SOURCE_DIR}/${_DIR}/*)
       add_custom_command(OUTPUT ${VOTCA_SPHINX_DIR}/xtp-tutorials/${_FILE}
         COMMAND ${CMAKE_COMMAND} -E copy_directory ${PROJECT_SOURCE_DIR}/${_DIR} ${CMAKE_CURRENT_BINARY_DIR}/${_DIR}
-        COMMAND ${CMAKE_COMMAND} -E env PATH=${XTP_PATH}:$ENV{PATH} VOTCASHARE=${VOTCASHARE} ${JUPYTER_EXECUTABLE} nbconvert --to notebook --ExecutePreprocessor.timeout=5000 --execute ${_FILE} --output ${VOTCA_SPHINX_DIR}/xtp-tutorials/${_FILE}
+        COMMAND ${CMAKE_COMMAND} -E env PATH=${XTP_PATH}:$ENV{PATH} VOTCASHARE=${VOTCASHARE} ${JUPYTER_EXECUTABLE} nbconvert --Application.log_level=0 --to notebook --ExecutePreprocessor.timeout=5000 --execute ${_FILE} --output ${VOTCA_SPHINX_DIR}/xtp-tutorials/${_FILE}
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${_DIR}
 	DEPENDS ${FILES}
       )


### PR DESCRIPTION
## Changes
In order to have a better understanding of how are the notebooks created using XTP, it would be better to set the log level to debug.